### PR TITLE
Add Manchester United News Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Project Saturday</title>
+    <title>Project Saturday - Man United News</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -11,44 +11,46 @@
         <h1>Welcome to Project Saturday</h1>
     </header>
     <main>
-        <section class="about">
-            <h2>About Us</h2>
-            <p>This is a simple project to demonstrate GitHub workflow.</p>
-        </section>
-        
-        <section class="features">
-            <h2>Our Features</h2>
-            <ul>
-                <li>Simple and clean design</li>
-                <li>Responsive layout</li>
-                <li>Modern CSS styling</li>
-                <li>Best practices implementation</li>
-            </ul>
-        </section>
-
-        <section class="showcase">
-            <h2>Project Showcase</h2>
-            <div class="projects">
-                <div class="project-card">
-                    <h3>Project 1</h3>
-                    <p>Description of the first project goes here.</p>
-                </div>
-                <div class="project-card">
-                    <h3>Project 2</h3>
-                    <p>Description of the second project goes here.</p>
-                </div>
+        <section class="manutd-news">
+            <h2>Manchester United Latest News</h2>
+            <div class="news-grid">
+                <article class="news-card">
+                    <h3>FA Cup Third Round Draw</h3>
+                    <p class="news-date">December 3, 2024</p>
+                    <p>Manchester United have been drawn away to Arsenal in a massive FA Cup third round clash. The tie between the tournament's two most successful teams will be played at the Emirates Stadium in January.</p>
+                </article>
+                <article class="news-card">
+                    <h3>Upcoming Fixtures</h3>
+                    <ul class="fixtures-list">
+                        <li>Premier League matches</li>
+                        <li>FA Cup - Arsenal (A) - January 2024</li>
+                        <li>Champions League knockout stages</li>
+                    </ul>
+                </article>
+                <article class="news-card">
+                    <h3>Transfer Updates</h3>
+                    <p>Stay tuned for the latest transfer news and rumors as the January transfer window approaches.</p>
+                </article>
             </div>
         </section>
 
-        <section class="contact">
-            <h2>Contact Us</h2>
-            <p>Email: info@projectsaturday.example</p>
-            <p>Phone: (555) 123-4567</p>
-            <p>Address: 123 Code Street, Developer City</p>
+        <section class="about">
+            <h2>About Us</h2>
+            <p>This is a simple project to demonstrate GitHub workflow and keep United fans updated with the latest news.</p>
+        </section>
+        
+        <section class="features">
+            <h2>Site Features</h2>
+            <ul>
+                <li>Latest Manchester United news updates</li>
+                <li>Match reports and fixtures</li>
+                <li>Transfer news coverage</li>
+                <li>Responsive design for all devices</li>
+            </ul>
         </section>
     </main>
     <footer>
-        <p>&copy; 2024 Project Saturday</p>
+        <p>&copy; 2024 Project Saturday - Man United News Hub</p>
     </footer>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -14,12 +14,13 @@ body {
 }
 
 header {
-    background-color: #333;
+    background-color: #DA291C;
     color: white;
-    padding: 1rem;
+    padding: 1.5rem;
     text-align: center;
     border-radius: 5px;
     margin-bottom: 2rem;
+    box-shadow: 0 3px 10px rgba(0,0,0,0.2);
 }
 
 main {
@@ -43,30 +44,49 @@ section:last-child {
 
 h2 {
     color: #333;
-    margin-bottom: 1rem;
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid #DA291C;
 }
 
-ul {
-    list-style-position: inside;
-    margin-left: 1rem;
-}
-
-.projects {
+.news-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1.5rem;
     margin-top: 1rem;
 }
 
-.project-card {
+.news-card {
     background-color: #f8f8f8;
-    padding: 1rem;
+    padding: 1.5rem;
     border-radius: 5px;
     border: 1px solid #ddd;
+    transition: transform 0.2s;
 }
 
-.contact p {
-    margin: 0.5rem 0;
+.news-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+}
+
+.news-date {
+    color: #666;
+    font-size: 0.9rem;
+    margin-bottom: 0.5rem;
+}
+
+.fixtures-list {
+    list-style-type: none;
+    margin: 1rem 0;
+}
+
+.fixtures-list li {
+    padding: 0.5rem 0;
+    border-bottom: 1px solid #eee;
+}
+
+.fixtures-list li:last-child {
+    border-bottom: none;
 }
 
 footer {
@@ -74,4 +94,18 @@ footer {
     padding: 1rem;
     margin-top: 2rem;
     color: #666;
+}
+
+@media (max-width: 768px) {
+    .news-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    body {
+        padding: 10px;
+    }
+    
+    main {
+        padding: 1rem;
+    }
 }


### PR DESCRIPTION
This PR adds a new Manchester United news section featuring:

- Latest FA Cup draw news
- Upcoming fixtures
- Transfer news section
- Updated styling with United's colors
- Responsive news card layout
- Hover effects and improved visual design

Changes include:
- New news section with grid layout
- Updated color scheme to match United's branding
- Improved responsive design
- Enhanced typography and spacing

Closes #3